### PR TITLE
chore: bump version to 0.0.8

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: iceqream
 Title: Interpretable Computational Engine for Quantitative Regression of Enhancer ATAC Motifs
-Version: 0.0.7
+Version: 0.0.8
 Authors@R: c(
     person("Aviezer", "Lifshitz", , "aviezer.lifshitz@weizmann.ac.il", role = c("aut", "cre")),
     person("Akhiad", "Bercovich", , "akhiad.bercovich@weizmann.ac.il", role = "aut"),


### PR DESCRIPTION
Aligns `DESCRIPTION` with the `0.0.8` NEWS section merged in #20. The package self-reported `0.0.7` while NEWS already documented the `0.0.8` release (including the breaking removal of the inert `normalize_energies` / `norm_motif_energies` arguments). One-line version bump; no code or behavior change.